### PR TITLE
Python >=3.9 fix

### DIFF
--- a/gost2012.py
+++ b/gost2012.py
@@ -61,7 +61,7 @@ def encodeKey(key, oids, algo="1.2.643.7.1.1.1.1"):
 		seq2,
 		pyasn1.type.univ.OctetString(bytes.fromhex(key))
 	)
-	return '-----BEGIN PRIVATE KEY-----\n{}-----END PRIVATE KEY-----\n'.format(base64.encodestring(encode(seq3)).decode("ascii"))
+	return '-----BEGIN PRIVATE KEY-----\n{}-----END PRIVATE KEY-----\n'.format(base64.encodebytes(encode(seq3)).decode("ascii"))
 
 def unwrap_gost(kek, data, sbox=DEFAULT_SBOX):
     if len(data) != 44:


### PR DESCRIPTION
Привет,

Этот маленький патч исправляет запуск на версиях питона 3.9 и новее.

`base64.encodestring()` деприкейтед в Python 3.1 и удален в Python 3.9, [ref](https://docs.python.org/3.8/library/base64.html#base64.encodestring).